### PR TITLE
Limit Oauth scope to read:org and user:email

### DIFF
--- a/lib/add-to-org.rb
+++ b/lib/add-to-org.rb
@@ -11,7 +11,7 @@ module AddToOrg
     include AddToOrg::Helpers
 
     set :github_options, {
-      :scopes => "user,user:email"
+      :scopes => "read:org,user:email"
     }
 
     use Rack::Session::Cookie, {


### PR DESCRIPTION
I believe this may be all we really need:

* What is their email?
* Are they already a member of the org?