### PR TITLE
Redirect user to requested URL after invitation acceptance

### DIFF
--- a/lib/add-to-org/views/success.erb
+++ b/lib/add-to-org/views/success.erb
@@ -6,7 +6,7 @@
   </head>
   <body>
     <h1>You're all set</h1>
-    <p>You should have recieved an email inviting you to join the organization.</p>
+    <p class="lead">You simply need to <a href="https://github.com/orgs/government/invitation?return_to=<%= ERB::Util.html_escape(redirect) %>">confirm your invitation to join the organization</a> on GitHub.</p>
     <p>Once confirmed, you will have access to <a href="<%= ERB::Util.html_escape(redirect) %>"><%= ERB::Util.html_escape(redirect) %></a>, the requested URL.</h1>
   </body>
 </html>

--- a/spec/add-to-org_spec.rb
+++ b/spec/add-to-org_spec.rb
@@ -82,7 +82,7 @@ describe "logged in user" do
       get "/"
       expect(stub).to have_been_requested
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to match(/You should have recieved an email inviting you to join the organization/)
+      expect(last_response.body).to match(/confirm your invitation to join the organization/)
     end
   end
 


### PR DESCRIPTION
I added a `return_to` argument to the pending invitation controller. Accepting an invitation with that parameter properly redirect the user to the requested URL after acceptance. No more need to jump back and forth to email.